### PR TITLE
Fixed changed POM dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,9 +159,9 @@
 			<version>0.10.0</version>
 		</dependency>
 		<dependency>
-			<groupId>com.lowagie</groupId>
-			<artifactId>itext</artifactId>
-			<version>4.2.1</version>
+			<groupId>com.itextpdf</groupId>
+			<artifactId>itextpdf</artifactId>
+			<version>5.5.6</version>
 		</dependency>
 		<dependency>
 			<groupId>org.freehep</groupId>


### PR DESCRIPTION
The current master branch cannot be build due to changed dependencies.
[WARNING] The artifact com.lowagie:itext:jar:4.2.1 has been relocated to com.itextpdf:itextpdf:jar:5.5.6

This pull request fixes the issue.
